### PR TITLE
Fix issues with modal

### DIFF
--- a/src/components/AlbumDetailsModal.vue
+++ b/src/components/AlbumDetailsModal.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card class="pa-1" min-height="500" max-height="100vh">
     <v-row class="d-flex justify-end" style="max-height: 60px">
-      <v-btn class="mr-3 mt-3" height="30" @click="close">
+      <v-btn class="mr-3 mt-3" height="30" flat @click="close">
         <v-icon size="25">mdi-close</v-icon>
       </v-btn>
     </v-row>
@@ -113,8 +113,14 @@ const emit = defineEmits(['closeEvent'])
   .v-list {
     padding: 0px !important;
     margin-bottom: -15px;
+    @media (max-width: 600px) {
+      margin-bottom: -10px;
+    }
   }
   .v-list-item {
+  @media (max-width: 600px) {
+    font-size: 13px;
+  }
     padding-left: 0px !important;
   }
 

--- a/src/components/RecordCollection.vue
+++ b/src/components/RecordCollection.vue
@@ -56,9 +56,8 @@
     </v-col>
     <v-col cols="12" lg="9" md="12">
     <!-- Need to lazy load these -->
+    <p v-if="showSearchResultsInfo" class="my-5">{{`Showing ${filteredAlbumArray.length} result(s) for "${selectedSearchParameter} - ${selectedSearchKeyword}"`}}</p>
     <v-row v-for="record in filteredAlbumArray" :key="record.id"> 
-      <p v-if="showSearchResultsInfo" class="my-5">{{`Showing 1 result for "${selectedSearchParameter} - ${selectedSearchKeyword}`}}</p>
-  
       <v-dialog max-width="1000" transition="false">
         <template v-slot:activator="{ props: activatorProps }">
           <album-results-item 


### PR DESCRIPTION
Fixed issues, mostly with album modal. These issues included:

- Some song titles getting cut off due to margin
- Close button was too big
- Results text was rendering in for loop-generated components rather than above the section